### PR TITLE
fix #7

### DIFF
--- a/lua/luminate/autocmds.lua
+++ b/lua/luminate/autocmds.lua
@@ -1,25 +1,33 @@
 local api = vim.api
 local highlight = require('luminate.highlight')
+local config = require('luminate.config').config
+local namespaces = require('luminate.config').namespaces
 local M = {}
+
+function M.set_additional_autocmds()
+  if config.paste.enabled then
+    M.attach_bytes_highlight('paste')
+  end
+end
 
 function M.set_autocmds()
   api.nvim_create_augroup('LuminateHighlight', { clear = true })
 
-  if require('luminate.config').config.yank.enabled then
+  if config.yank.enabled then
     api.nvim_create_autocmd('TextYankPost', {
       group = 'LuminateHighlight',
       callback = function() M.on_yank() end
     })
   end
 
-  if require('luminate.config').config.paste.enabled then
+  if config.paste.enabled then
     api.nvim_create_autocmd('TextChanged', {
       group = 'LuminateHighlight',
       callback = function() M.attach_bytes_highlight('paste') end
     })
   end
 
-  if require('luminate.config').config.undo.enabled or require('luminate.config').config.redo.enabled then
+  if config.undo.enabled or config.redo.enabled then
     api.nvim_create_autocmd('BufEnter', {
       group = 'LuminateHighlight',
       callback = function() M.attach_bytes_highlight('undo_redo') end
@@ -29,25 +37,19 @@ end
 
 function M.on_yank()
   vim.highlight.on_yank({
-    higroup = require('luminate.config').config.yank.hlgroup,
-    timeout = require('luminate.config').config.duration,
-    namespace = require('luminate.config').namespaces.yank,
+    higroup = config.yank.hlgroup,
+    timeout = config.duration,
+    namespace = namespaces.yank,
   })
 end
 
 function M.attach_bytes_highlight(event_type)
-  require('luminate.config').config.should_detach = false
+  config.should_detach = false
   api.nvim_buf_attach(0, false, {
-    on_bytes = function(ignored, bufnr, changedtick,
-                        start_row, start_column,
-                        byte_offset, old_end_row,
-                        old_end_col, old_end_byte,
-                        new_end_row, new_end_col, new_end_byte)
-      highlight.on_bytes(event_type, bufnr, changedtick,
-        start_row, start_column,
-        byte_offset, old_end_row,
-        old_end_col, old_end_byte,
-        new_end_row, new_end_col, new_end_byte)
+    on_bytes = function(_, bufnr, changedtick, start_row, start_column, byte_offset, old_end_row, old_end_col,
+                        old_end_byte, new_end_row, new_end_col, new_end_byte)
+      highlight.on_bytes(event_type, bufnr, changedtick, start_row, start_column, byte_offset, old_end_row, old_end_col,
+        old_end_byte, new_end_row, new_end_col, new_end_byte)
     end,
   })
 end

--- a/lua/luminate/highlight.lua
+++ b/lua/luminate/highlight.lua
@@ -1,20 +1,19 @@
 local api = vim.api
+local config = require('luminate.config').config
+local namespaces = require('luminate.config').namespaces
 local M = {}
 
 function M.set_highlight(name, params)
   api.nvim_set_hl(0, name, params)
 end
 
-function M.on_bytes(event_type, bufnr, changedtick,
-                    start_row, start_column,
-                    byte_offset, old_end_row,
-                    old_end_col, old_end_byte,
-                    new_end_row, new_end_col, new_end_byte)
-  if require('luminate.config').config.should_detach or vim.fn.mode() == 'i' then
+function M.on_bytes(event_type, bufnr, changedtick, start_row, start_column, byte_offset, old_end_row, old_end_col,
+                    old_end_byte, new_end_row, new_end_col, new_end_byte)
+  if config.should_detach or vim.fn.mode() == 'i' then
     return true
   end
 
-  local config = require('luminate.config').config[event_type]
+  local event_config = config[event_type]
   local num_lines = api.nvim_buf_line_count(bufnr)
   local end_row = start_row + new_end_row
   local end_col = start_column + new_end_col
@@ -24,16 +23,15 @@ function M.on_bytes(event_type, bufnr, changedtick,
   end
 
   vim.schedule(function()
-    if (end_row - start_row) / num_lines <= config.HIGHLIGHT_THRESHOLD then
+    if (end_row - start_row) / num_lines <= event_config.HIGHLIGHT_THRESHOLD then
       vim.highlight.range(
         bufnr,
-        require('luminate.config').namespaces[event_type],
-        config.hlgroup,
+        namespaces[event_type],
+        event_config.hlgroup,
         { start_row, start_column },
         { end_row, end_col }
       )
-
-      M.defer_clear_highlights(bufnr, require('luminate.config').namespaces[event_type])
+      M.defer_clear_highlights(bufnr, namespaces[event_type])
     end
   end)
 end
@@ -41,7 +39,7 @@ end
 function M.defer_clear_highlights(bufnr, namespace)
   vim.defer_fn(function()
     api.nvim_buf_clear_namespace(bufnr, namespace, 0, -1)
-  end, require('luminate.config').config.duration)
+  end, config.duration)
 end
 
 return M

--- a/lua/luminate/undo_redo.lua
+++ b/lua/luminate/undo_redo.lua
@@ -1,5 +1,6 @@
 local api = vim.api
 local highlight = require('luminate.highlight')
+local config = require('luminate.config').config
 local M = {}
 
 function M.call_original_kemap(map)
@@ -17,24 +18,18 @@ function M.open_folds_on_undo()
 end
 
 function M.highlight_undo_redo(event_type, command)
-  require('luminate.config').config.current_hlgroup = require('luminate.config').config[event_type].hlgroup
-  require('luminate.config').config.should_detach = false
+  config.current_hlgroup = config[event_type].hlgroup
+  config.should_detach = false
 
   api.nvim_buf_attach(0, false, {
-    on_bytes = function(ignored, bufnr, changedtick,
-                        start_row, start_column,
-                        byte_offset, old_end_row,
-                        old_end_col, old_end_byte,
-                        new_end_row, new_end_col, new_end_byte)
-      highlight.on_bytes(event_type, bufnr, changedtick,
-        start_row, start_column,
-        byte_offset, old_end_row,
-        old_end_col, old_end_byte,
-        new_end_row, new_end_col, new_end_byte)
+    on_bytes = function(_, bufnr, changedtick, start_row, start_column, byte_offset, old_end_row, old_end_col,
+                        old_end_byte, new_end_row, new_end_col, new_end_byte)
+      highlight.on_bytes(event_type, bufnr, changedtick, start_row, start_column, byte_offset, old_end_row, old_end_col,
+        old_end_byte, new_end_row, new_end_col, new_end_byte)
     end,
   })
 
-  if require('luminate.config').config.highlight_for_count then
+  if config.highlight_for_count then
     for _ = 1, vim.v.count1 do
       command()
     end
@@ -42,8 +37,7 @@ function M.highlight_undo_redo(event_type, command)
     command()
   end
 
-  require('luminate.config').config.should_detach = true
+  config.should_detach = true
 end
 
 return M
-


### PR DESCRIPTION
This commit refactors the way the 'luminate' plugin handles its configuration. Previously, the configuration was repeatedly imported and accessed in multiple places, leading to verbose and repetitive code.

Now, the configuration is imported once at the top of each file and stored in a local variable. This makes the code cleaner and more efficient, as the configuration is only imported once.

Additionally, the setup function in 'init.lua' has been refactored to improve readability. The code for setting highlight groups and keymaps has been moved into separate functions, making the setup function easier to read and understand.

This refactor should not affect the functionality of the plugin, but it makes the codebase easier to maintain and extend in the future.