### PR TITLE
feat: change paste mapping in luminate config

### DIFF
--- a/lua/luminate/config.lua
+++ b/lua/luminate/config.lua
@@ -19,7 +19,7 @@ local config = {
     enabled = true,
     mode = 'n',
     lhs = { 'p', 'P' },
-    map = { p = '"+p', P = '"+P' },
+    map = { p = '""p', P = '""P' },
     opts = {},
   },
   undo = {
@@ -56,4 +56,3 @@ return {
   config = config,
   namespaces = namespaces,
 }
-


### PR DESCRIPTION
This commit changes the paste mapping in the luminate configuration from using the system clipboard to using the unnamed register. This change was made to improve compatibility with environments where the system clipboard is not accessible or reliable. The new mapping uses the unnamed register, which is always available in Vim, to paste content. This should make the paste functionality more reliable across different environments.

close #15 