### PR TITLE
Address #8 and #15

### DIFF
--- a/lua/luminate/actions.lua
+++ b/lua/luminate/actions.lua
@@ -2,14 +2,6 @@ local api = vim.api
 local highlight = require('luminate.highlight')
 local M = {}
 
-function M.call_original_map(map)
-  if type(map) == 'string' then
-    vim.cmd('normal! ' .. map)
-  elseif type(map) == 'function' then
-    map()
-  end
-end
-
 function M.open_folds_on_undo()
   if vim.tbl_contains(vim.opt.foldopen:get(), "undo") then
     vim.cmd.normal({ "zv", bang = true })

--- a/lua/luminate/autocmds.lua
+++ b/lua/luminate/autocmds.lua
@@ -14,21 +14,24 @@ function M.set_autocmds()
   end
 
   if config_module.config.paste.enabled then
-    api.nvim_create_autocmd('BufEnter', {
+    api.nvim_create_autocmd('User', {
+      pattern = { 'Luminate_paste' },
       group = 'LuminateHighlight',
       callback = function() M.attach_bytes_highlight('paste') end
     })
   end
 
   if config_module.config.undo.enabled then
-    api.nvim_create_autocmd('BufEnter', {
+    api.nvim_create_autocmd('User', {
+      pattern = { 'Luminate_undo' },
       group = 'LuminateHighlight',
       callback = function() M.attach_bytes_highlight('undo') end
     })
   end
 
   if config_module.config.redo.enabled then
-    api.nvim_create_autocmd('BufEnter', {
+    api.nvim_create_autocmd('User', {
+      pattern = { 'Luminate_redo' },
       group = 'LuminateHighlight',
       callback = function() M.attach_bytes_highlight('redo') end
     })

--- a/lua/luminate/config.lua
+++ b/lua/luminate/config.lua
@@ -45,6 +45,8 @@ local config = {
 local namespaces = {
   yank = api.nvim_create_namespace('LuminateYankHighlight'),
   paste = api.nvim_create_namespace('LuminatePasteHighlight'),
+  undo = api.nvim_create_namespace('LuminateUndoHighlight'),
+  redo = api.nvim_create_namespace('LuminateRedoHighlight'),
   undo_redo = api.nvim_create_namespace('LuminateUndoRedoHighlight')
 }
 

--- a/lua/luminate/config.lua
+++ b/lua/luminate/config.lua
@@ -19,7 +19,6 @@ local config = {
     enabled = true,
     mode = 'n',
     lhs = { 'p', 'P' },
-    map = { p = 'p', P = 'P' },
     opts = {},
   },
   undo = {
@@ -29,7 +28,6 @@ local config = {
     enabled = true,
     mode = 'n',
     lhs = { 'u', 'U' },
-    map = { u = 'u', U = 'U' },
     opts = {},
   },
   redo = {
@@ -39,7 +37,6 @@ local config = {
     enabled = true,
     mode = 'n',
     lhs = { '<C-r>' },
-    map = '<C-r>',
     opts = {},
   },
   highlight_for_count = true,
@@ -48,8 +45,7 @@ local config = {
 local namespaces = {
   yank = api.nvim_create_namespace('LuminateYankHighlight'),
   paste = api.nvim_create_namespace('LuminatePasteHighlight'),
-  undo = api.nvim_create_namespace('LuminateUndoHighlight'),
-  redo = api.nvim_create_namespace('LuminateRedoHighlight'),
+  undo_redo = api.nvim_create_namespace('LuminateUndoRedoHighlight')
 }
 
 return {

--- a/lua/luminate/highlight.lua
+++ b/lua/luminate/highlight.lua
@@ -15,6 +15,8 @@ function M.on_bytes(event_type, bufnr, changedtick, start_row, start_column, byt
   end
 
   local event_config = config_module.config[event_type]
+  if not event_config then print("Luminate.nvim ERROR: Could not find correct config for event type" .. event_type) return end
+
   local num_lines = api.nvim_buf_line_count(bufnr)
   local end_row = start_row + new_end_row
   local end_col = start_column + new_end_col
@@ -27,6 +29,7 @@ function M.on_bytes(event_type, bufnr, changedtick, start_row, start_column, byt
     return true
   end
 
+  if not namespaces[event_type] then print("Luminate.nvim ERROR: Could not find namespace for " .. event_type .. " highlighting.") return end
   vim.schedule(function()
     vim.highlight.range(
       bufnr,
@@ -40,7 +43,6 @@ function M.on_bytes(event_type, bufnr, changedtick, start_row, start_column, byt
 end
 
 function M.defer_clear_highlights(bufnr, namespace)
-  if not api.nvim_buf_is_valid(bufnr) then return end
   vim.defer_fn(function()
     api.nvim_buf_clear_namespace(bufnr, namespace, 0, -1)
   end, config_module.config.duration)

--- a/lua/luminate/init.lua
+++ b/lua/luminate/init.lua
@@ -33,7 +33,7 @@ local function set_keymaps()
           api.nvim_exec_autocmds("User", { "Luminate_" .. action })
         end
         or ""),
-        { noremap = true, desc = original_map.desc or nil }
+        { noremap = true, desc = original_map.desc or "" }
       )
     end
   end

--- a/lua/luminate/init.lua
+++ b/lua/luminate/init.lua
@@ -20,23 +20,21 @@ end
 local function set_keymaps()
   local function set_keymap_for_action(action, keys)
     local config = config_module.config[action]
-    if not config.enabled then return end
+    if not config then print("LUMINATE.NVIM ERROR: config is nil.") return end
+    local mappings = api.nvim_get_keymap(config.mode)
+    local buf_mappings = api.nvim_buf_get_keymap(0, config.mode)
     for _, lhs in ipairs(keys) do
-      vim.keymap.set(config.mode, lhs, function()
-        if config_module.config.highlight_for_count or vim.v.count == 0 then
-          actions.highlight_action(config_module, action, function()
-            if lhs == '<C-r>' then
-              vim.cmd('redo')
-            else
-              actions.call_original_map(config.map[lhs] or config.map)
-            end
-          end)
-        else
-          local key_sequence = api.nvim_replace_termcodes(vim.v.count .. lhs, true, false, true)
-          api.nvim_feedkeys(key_sequence, 'n', false)
+      local original_map = mappings[lhs] or buf_mappings[lhs] or {}
+      local rhs = original_map.rhs or original_map.callback or lhs
+      vim.keymap.set(config.mode, lhs,
+        (type(rhs) == "string" and rhs .. " <cmd>doautocmd User Luminate_" .. action .. "<CR>")
+        or (type(rhs) == "function" and function ()
+          rhs()
+          api.nvim_exec_autocmds("User", { "Luminate_" .. action })
         end
-        actions.open_folds_on_undo()
-      end, config.opts)
+        or ""),
+        { noremap = true, desc = original_map.desc or nil }
+      )
     end
   end
 


### PR DESCRIPTION
* Fixes a namespace to event_type mismatch.
* Adds some error and nil checking with debug messages.
* Create autocommands on User instead of BufEnter, calling the autocommand on keypress.
* Replace call_original_map with a original mapping rebind with
  autocommand call appended to:
  - Respect original keymapping with description
  - Better respond to built-in behaviors on yank, paste and undo/redo.
  - Removed uneccessary "map" table in config.

* Relies on some Neovim 0.7 features, might be advisible to add a
  feature test.

Alternative to the description, the string can be "which_key_ignore", which will make it not pop up in Which_Key plugin.

Issue: It seems that the 'o' and 'O' keymaps (that append or prepend a new line and enters insert mode) calls to the event for highlighting with the event_type "undo". No idea why.
Please try it out before merging. I did remap the put key "p" to test, and it preserves the original description, as well as provide pasting with register interaction like it's supposed to.
```lua
map("n", "u", "u <cmd>print<CR>")
map("n", "p", "p <cmd>print<CR>", { desc = "lamo gotem"})
```

Furthermore we should probably advocate for TextPutPost, TextUndoPost and TextRedoPost autocommands provided by Neovim, inline with TextYankPost for better highlighting support. :)